### PR TITLE
JSONToNML.__init__() TypeError logic

### DIFF
--- a/glmpy/glm_json.py
+++ b/glmpy/glm_json.py
@@ -26,7 +26,7 @@ class JSONToNML:
     def __init__(
         self, json_file: str | os.PathLike, nml_file: str = "sim.nml"
     ):
-        if not isinstance(json_file, str) or not isinstance(json_file, dict):
+        if not isinstance(json_file, str) and not isinstance(json_file, dict):
             raise TypeError("Expected json_file to be a string or dict.")
         if not isinstance(nml_file, str):
             raise TypeError("Expected nml_file to be a string.")


### PR DESCRIPTION
The logic to evaluate whether to raise a `TypeError` for the `json_file` parameter resulted in the error always being raised.

`if not isinstance(json_file, str) or not isinstance(json_file, dict)` raises the error if `json_file` is of type `str` or typ `dict`. 

Changed `or` to `and` so the error is only raised if `json_file` is not a `str` and it's not a `dict`.